### PR TITLE
Add basic support for trilogy

### DIFF
--- a/database_cleaner-active_record.gemspec
+++ b/database_cleaner-active_record.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "trilogy"
 end

--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -64,7 +64,7 @@ module DatabaseCleaner
       end
 
       def information_schema_exists? connection
-        connection.adapter_name == "Mysql2"
+        connection.adapter_name.in?(["Mysql2", "Trilogy"])
       end
     end
   end

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -62,7 +62,7 @@ module DatabaseCleaner
       def initialize(connection)
         extend AbstractAdapter
         case connection.adapter_name
-        when "Mysql2"
+        when "Mysql2", "Trilogy"
           extend AbstractMysqlAdapter
         when "SQLite"
           extend AbstractMysqlAdapter

--- a/spec/database_cleaner/active_record/deletion_spec.rb
+++ b/spec/database_cleaner/active_record/deletion_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Deletion do
           subject(:strategy) { described_class.new(cache_tables: true) }
 
           it 'caches the list of tables to be deleted from' do
-            if helper.db == :mysql2
+            if helper.db.in([:mysql2, :trilogy])
               expect(strategy).to receive(:build_table_stats_query).once.and_return("")
             elsif helper.db == :postgres
               expect(strategy.send(:connection)).to receive(:tables_with_schema).once.and_return([])
@@ -108,7 +108,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Deletion do
           subject(:strategy) { described_class.new(cache_tables: false) }
 
           it 'does not cache the list of tables to be deleted from' do
-            if helper.db == :mysql2
+            if helper.db.in([:mysql2, :trilogy])
               expect(strategy).to receive(:build_table_stats_query).twice.and_return("")
             elsif helper.db == :postgres
               expect(strategy.send(:connection)).to receive(:tables_with_schema).twice.and_return([])

--- a/spec/support/database_helper.rb
+++ b/spec/support/database_helper.rb
@@ -3,7 +3,7 @@ require 'database_cleaner/spec/database_helper'
 
 class DatabaseHelper < DatabaseCleaner::Spec::DatabaseHelper
   def self.with_all_dbs &block
-    %w[mysql2 sqlite3 postgres].map(&:to_sym).each do |db|
+    %w[mysql2 sqlite3 postgres trilogy].map(&:to_sym).each do |db|
       yield new(db)
     end
   end


### PR DESCRIPTION
* [Trilogy](https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/) is github's alternative to mysql2
* Basically anywhere there's something for mysql2 just do the same thing for Trilogy
* Since the database is the same between the two adapters think this is reasonable